### PR TITLE
複数のEventの追加、EventValuesの定義を抽象化、Skriptでは実装されていないEventValuesを削除

### DIFF
--- a/src/main/java/jp/nlaocs/skriptcatchup/elements/eventValues/valPlayerMoveEvent.java
+++ b/src/main/java/jp/nlaocs/skriptcatchup/elements/eventValues/valPlayerMoveEvent.java
@@ -1,0 +1,43 @@
+package jp.nlaocs.skriptcatchup.elements.eventValues;
+
+import ch.njol.skript.registrations.EventValues;
+import ch.njol.skript.util.Getter;
+import org.bukkit.Chunk;
+import org.bukkit.Location;
+import org.bukkit.block.Block;
+import org.bukkit.event.player.PlayerMoveEvent;
+
+public class valPlayerMoveEvent {
+    static {
+        EventValues.registerEventValue(PlayerMoveEvent.class, Chunk.class, new Getter<Chunk, PlayerMoveEvent>() {
+            @Override
+            public Chunk get(PlayerMoveEvent event) {
+                return event.getTo().getChunk();
+            }
+        }, EventValues.TIME_NOW);
+        EventValues.registerEventValue(PlayerMoveEvent.class, Chunk.class, new Getter<Chunk, PlayerMoveEvent>() {
+            @Override
+            public Chunk get(PlayerMoveEvent event) {
+                return event.getFrom().getChunk();
+            }
+        }, EventValues.TIME_PAST);
+        EventValues.registerEventValue(PlayerMoveEvent.class, Location.class, new Getter<Location, PlayerMoveEvent>() {
+            @Override
+            public Location get(PlayerMoveEvent event) {
+                return event.getFrom();
+            }
+        }, EventValues.TIME_PAST);
+        EventValues.registerEventValue(PlayerMoveEvent.class, Block.class, new Getter<Block, PlayerMoveEvent>() {
+            @Override
+            public Block get(PlayerMoveEvent event) {
+                return event.getTo().clone().subtract(0, 0.5, 0).getBlock();
+            }
+        }, EventValues.TIME_NOW);
+        EventValues.registerEventValue(PlayerMoveEvent.class, Location.class, new Getter<Location, PlayerMoveEvent>() {
+            @Override
+            public Location get(PlayerMoveEvent event) {
+                return event.getTo();
+            }
+        }, EventValues.TIME_NOW);
+    }
+}

--- a/src/main/java/jp/nlaocs/skriptcatchup/elements/events/EvtPlayerChunkEnter.java
+++ b/src/main/java/jp/nlaocs/skriptcatchup/elements/events/EvtPlayerChunkEnter.java
@@ -4,10 +4,6 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptEvent;
 import ch.njol.skript.lang.SkriptParser;
-import ch.njol.skript.registrations.EventValues;
-import ch.njol.skript.util.Getter;
-import org.bukkit.Chunk;
-import org.bukkit.Location;
 import org.bukkit.event.Event;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.jetbrains.annotations.Nullable;
@@ -21,24 +17,6 @@ public class EvtPlayerChunkEnter extends SkriptEvent {
                         "on player enters a chunk:",
                         "\tsend \"You entered a chunk: %past event-chunk% -> %event-chunk%!\" to player"
                 ).since("2.7");
-        EventValues.registerEventValue(PlayerMoveEvent.class, Chunk.class, new Getter<Chunk, PlayerMoveEvent>() {
-            @Override
-            public Chunk get(PlayerMoveEvent event) {
-                return event.getTo().getChunk();
-            }
-        }, EventValues.TIME_NOW);
-        EventValues.registerEventValue(PlayerMoveEvent.class, Chunk.class, new Getter<Chunk, PlayerMoveEvent>() {
-            @Override
-            public Chunk get(PlayerMoveEvent event) {
-                return event.getFrom().getChunk();
-            }
-        }, EventValues.TIME_PAST);
-        EventValues.registerEventValue(PlayerMoveEvent.class, Location.class, new Getter<Location, PlayerMoveEvent>() {
-            @Override
-            public Location get(PlayerMoveEvent event) {
-                return event.getFrom();
-            }
-        }, EventValues.TIME_PAST);
     }
 
     @Override

--- a/src/main/java/jp/nlaocs/skriptcatchup/elements/events/EvtTeleport.java
+++ b/src/main/java/jp/nlaocs/skriptcatchup/elements/events/EvtTeleport.java
@@ -6,7 +6,6 @@ import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptEvent;
 import ch.njol.skript.lang.SkriptParser;
 import ch.njol.skript.registrations.EventValues;
-import ch.njol.skript.util.Experience;
 import ch.njol.skript.util.Getter;
 import ch.njol.util.coll.CollectionUtils;
 import org.bukkit.Chunk;
@@ -15,7 +14,6 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.Event;
 import org.bukkit.event.entity.EntityTeleportEvent;
-import org.bukkit.event.player.PlayerExpChangeEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.jetbrains.annotations.Nullable;
 
@@ -33,20 +31,6 @@ public class EvtTeleport extends SkriptEvent {
                         "on creeper teleport:"
                 )
                 .since("1.0, 2.9.0 (entity teleport)");
-        EventValues.registerEventValue(PlayerTeleportEvent.class, Location.class, new Getter<Location, PlayerTeleportEvent>() {
-            @Override
-            @Nullable
-            public Location get(PlayerTeleportEvent event) {
-                return event.getTo();
-            }
-        }, EventValues.TIME_NOW);
-        EventValues.registerEventValue(PlayerTeleportEvent.class, Block.class, new Getter<Block, PlayerTeleportEvent>() {
-            @Override
-            @Nullable
-            public Block get(PlayerTeleportEvent event) {
-                return event.getTo().clone().subtract(0, 0.5, 0).getBlock();
-            }
-        }, EventValues.TIME_NOW);
         EventValues.registerEventValue(EntityTeleportEvent.class, Location.class, new Getter<Location, EntityTeleportEvent>() {
             @Override
             public @Nullable Location get(EntityTeleportEvent event) {

--- a/src/main/java/jp/nlaocs/skriptcatchup/elements/events/EvtTeleport.java
+++ b/src/main/java/jp/nlaocs/skriptcatchup/elements/events/EvtTeleport.java
@@ -43,7 +43,7 @@ public class EvtTeleport extends SkriptEvent {
                 return event.getTo();
             }
         }, EventValues.TIME_NOW);
-        EventValues.registerEventValue(EntityTeleportEvent.class, Block.class, new Getter<Block, EntityTeleportEvent>() {
+        /*EventValues.registerEventValue(EntityTeleportEvent.class, Block.class, new Getter<Block, EntityTeleportEvent>() {
             @Override
             public @Nullable Block get(EntityTeleportEvent event) {
                 return event.getTo().clone().subtract(0, 0.5, 0).getBlock();
@@ -60,7 +60,7 @@ public class EvtTeleport extends SkriptEvent {
             public @Nullable Chunk get(EntityTeleportEvent event) {
                 return event.getFrom().getChunk();
             }
-        }, EventValues.TIME_PAST);
+        }, EventValues.TIME_PAST);*/
     }
 
     @Nullable

--- a/src/main/java/jp/nlaocs/skriptcatchup/elements/events/EvtWorld.java
+++ b/src/main/java/jp/nlaocs/skriptcatchup/elements/events/EvtWorld.java
@@ -1,0 +1,74 @@
+package jp.nlaocs.skriptcatchup.elements.events;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.lang.Literal;
+import ch.njol.skript.lang.LiteralList;
+import ch.njol.skript.lang.SkriptEvent;
+import ch.njol.skript.lang.SkriptParser;
+import org.bukkit.World;
+import org.bukkit.event.Event;
+import org.bukkit.event.world.*;
+import org.jetbrains.annotations.Nullable;
+
+public class EvtWorld extends SkriptEvent {
+
+    static {
+        // World Save Event
+        Skript.registerEvent("World Save", EvtWorld.class, WorldSaveEvent.class, "[catch[ ]up] world sav(e|ing) [of %-worlds%]")
+                .description("Called when a world is saved to disk. Usually all worlds are saved simultaneously, but world management plugins could change this.")
+                .examples(
+                        "on world save of \"world\":",
+                        "\tbroadcast \"The world %event-world% has been saved\"")
+                .since("1.0, 2.8.0 (defining worlds)");
+
+        // World Init Event
+        Skript.registerEvent("World Init", EvtWorld.class, WorldInitEvent.class, "[catch[ ]up] world init[ialization] [of %-worlds%]")
+                .description("Called when a world is initialized. As all default worlds are initialized before",
+                        "any scripts are loaded, this event is only called for newly created worlds.",
+                        "World management plugins might change the behaviour of this event though.")
+                .examples("on world init of \"world_the_end\":")
+                .since("1.0, 2.8.0 (defining worlds)");
+
+        // World Unload Event
+        Skript.registerEvent("World Unload", EvtWorld.class, WorldUnloadEvent.class, "[catch[ ]up] world unload[ing] [of %-worlds%]")
+                .description("Called when a world is unloaded. This event will never be called if you don't have a world management plugin.")
+                .examples(
+                        "on world unload:",
+                        "\tbroadcast \"the %event-world% has been unloaded!\"")
+                .since("1.0, 2.8.0 (defining worlds)");
+
+        // World Load Event
+        Skript.registerEvent("World Load", EvtWorld.class, WorldLoadEvent.class, "[catch[ ]up] world load[ing] [of %-worlds%]")
+                .description("Called when a world is loaded. As with the world init event, this event will not be called for the server's default world(s).")
+                .examples(
+                        "on world load of \"world_nether\":",
+                        "\tbroadcast \"The world %event-world% has been loaded!\"")
+                .since("1.0, 2.8.0 (defining worlds)");
+    }
+
+    private Literal<World> worlds;
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean init(Literal<?>[] args, int matchedPattern, SkriptParser.ParseResult parseResult) {
+        worlds = (Literal<World>) args[0];
+        if (worlds instanceof LiteralList<?> && worlds.getAnd()) {
+            ((LiteralList<World>) worlds).invertAnd();
+        }
+        return true;
+    }
+
+    @Override
+    public boolean check(Event event) {
+        if (worlds == null)
+            return true;
+        World evtWorld = ((WorldEvent) event).getWorld();
+        return worlds.check(event, world -> world.equals(evtWorld));
+    }
+
+    @Override
+    public String toString(@Nullable Event event, boolean debug) {
+        return "world save/init/unload/load" + (worlds == null ? "" : " of " + worlds.toString(event,debug));
+    }
+
+}


### PR DESCRIPTION
複数のイベント
[On World Init](https://skripthub.net/docs/?id=1068)
[On World Load](https://skripthub.net/docs/?id=1069)
[On World Save](https://skripthub.net/docs/?id=1070)
[On World Unload](https://skripthub.net/docs/?id=1071)
を追加

EventValues(主にPlayerTeleportEventに関するもの)を抽象化

Skriptでは実装されていないEntityTeleportEventのevent-block, event-chunk, past event-chunkを削除