### PR TITLE
Revert "Conditionでの識別子の付け方を変更"

### DIFF
--- a/src/main/java/jp/nlaocs/skriptcatchup/elements/conditions/CondCanPickUpItems.java
+++ b/src/main/java/jp/nlaocs/skriptcatchup/elements/conditions/CondCanPickUpItems.java
@@ -21,7 +21,7 @@ import org.bukkit.entity.LivingEntity;
 public class CondCanPickUpItems extends PropertyCondition<LivingEntity> {
 
     static {
-        register(CondCanPickUpItems.class, PropertyType.CAN, "pick([ ]up items| items up) [catch[ ]up]", "livingentities");
+        register(CondCanPickUpItems.class, PropertyType.CAN, "[catch[ ]up] pick([ ]up items| items up)", "livingentities");
     }
 
     @Override

--- a/src/main/java/jp/nlaocs/skriptcatchup/elements/conditions/CondHasItemCooldown.java
+++ b/src/main/java/jp/nlaocs/skriptcatchup/elements/conditions/CondHasItemCooldown.java
@@ -26,10 +26,10 @@ public class CondHasItemCooldown extends Condition {
 
     static {
         Skript.registerCondition(CondHasItemCooldown.class,
-                "%players% (has|have) [([an] item|a)] cooldown (on|for) %itemtypes% [catch[ ]up]",
-                "%players% (has|have) %itemtypes% on [(item|a)] cooldown [catch[ ]up]",
-                "%players% (doesn't|does not|do not|don't) have [([an] item|a)] cooldown (on|for) %itemtypes% [catch[ ]up]",
-                "%players% (doesn't|does not|do not|don't) have %itemtypes% on [(item|a)] cooldown [catch[ ]up]");
+                "%players% (has|have) [catch[ ]up] [([an] item|a)] cooldown (on|for) %itemtypes%",
+                "%players% (has|have) [catch[ ]up] %itemtypes% on [(item|a)] cooldown",
+                "%players% (doesn't|does not|do not|don't) have [catch[ ]up] [([an] item|a)] cooldown (on|for) %itemtypes%",
+                "%players% (doesn't|does not|do not|don't) have [catch[ ]up] %itemtypes% on [(item|a)] cooldown");
     }
 
     private Expression<Player> players;

--- a/src/main/java/jp/nlaocs/skriptcatchup/elements/conditions/CondHasLineOfSight.java
+++ b/src/main/java/jp/nlaocs/skriptcatchup/elements/conditions/CondHasLineOfSight.java
@@ -27,9 +27,9 @@ public class CondHasLineOfSight extends Condition {
 
     static {
         Skript.registerCondition(CondHasLineOfSight.class,
-                "%livingentities% (has|have) [a] [direct] line of sight to %entities/locations% [catch[ ]up]",
-                "%livingentities% does(n't| not) have [a] [direct] line of sight to %entities/locations% [catch[ ]up]",
-                "%livingentities% (has|have) no [direct] line of sight to %entities/locations% [catch[ ]up]");
+                "%livingentities% (has|have) [catch[ ]up] [a] [direct] line of sight to %entities/locations%",
+                "%livingentities% does(n't| not) have [catch[ ]up] [a] [direct] line of sight to %entities/locations%",
+                "%livingentities% (has|have) [catch[ ]up] no [direct] line of sight to %entities/locations%");
     }
 
     private Expression<LivingEntity> viewers;

--- a/src/main/java/jp/nlaocs/skriptcatchup/elements/conditions/CondIsGliding.java
+++ b/src/main/java/jp/nlaocs/skriptcatchup/elements/conditions/CondIsGliding.java
@@ -15,7 +15,7 @@ import ch.njol.skript.conditions.base.PropertyCondition;
 public class CondIsGliding extends PropertyCondition<LivingEntity> {
 
     static {
-        register(CondIsGliding.class, "gliding [catch[ ]up]", "livingentities");
+        register(CondIsGliding.class, "[catch[ ]up] gliding", "livingentities");
     }
 
     @Override

--- a/src/main/java/jp/nlaocs/skriptcatchup/elements/conditions/CondIsLeftHanded.java
+++ b/src/main/java/jp/nlaocs/skriptcatchup/elements/conditions/CondIsLeftHanded.java
@@ -30,7 +30,7 @@ public class CondIsLeftHanded extends PropertyCondition<LivingEntity> {
 
 
     static {
-        register(CondIsLeftHanded.class, PropertyType.BE, "(:left|right)( |-)handed [catch[ ]up]", "livingentities");
+        register(CondIsLeftHanded.class, PropertyType.BE, "[catch[ ]up] (:left|right)( |-)handed", "livingentities");
     }
 
     private MainHand hand;

--- a/src/main/java/jp/nlaocs/skriptcatchup/elements/conditions/CondIsOp.java
+++ b/src/main/java/jp/nlaocs/skriptcatchup/elements/conditions/CondIsOp.java
@@ -14,7 +14,7 @@ import org.bukkit.OfflinePlayer;
 public class CondIsOp extends PropertyCondition<OfflinePlayer> {
 
     static {
-        register(CondIsOp.class, PropertyType.BE, "[[a] server|an] op[erator][s] [catch[ ]up]", "offlineplayers");
+        register(CondIsOp.class, PropertyType.BE, "[catch[ ]up] [[a] server|an] op[erator][s]", "offlineplayers");
     }
 
     @Override

--- a/src/main/java/jp/nlaocs/skriptcatchup/elements/conditions/CondIsStackable.java
+++ b/src/main/java/jp/nlaocs/skriptcatchup/elements/conditions/CondIsStackable.java
@@ -18,7 +18,7 @@ import ch.njol.skript.doc.Since;
 public class CondIsStackable extends PropertyCondition<ItemStack> {
 
     static {
-        register(CondIsStackable.class, "stackable [catch[ ]up]", "itemstacks");
+        register(CondIsStackable.class, "[catch[ ]up] stackable", "itemstacks");
     }
 
     @Override

--- a/src/main/java/jp/nlaocs/skriptcatchup/elements/conditions/CondIsUnbreakable.java
+++ b/src/main/java/jp/nlaocs/skriptcatchup/elements/conditions/CondIsUnbreakable.java
@@ -22,7 +22,7 @@ import ch.njol.util.Kleenean;
 public class CondIsUnbreakable extends PropertyCondition<ItemType> {
 
     static {
-        register(CondIsUnbreakable.class, "[:un]breakable [catch[ ]up]", "itemtypes");
+        register(CondIsUnbreakable.class, "[catch[ ]up] [:un]breakable", "itemtypes");
     }
 
     private boolean breakable;

--- a/src/main/java/jp/nlaocs/skriptcatchup/elements/conditions/CondIsValid.java
+++ b/src/main/java/jp/nlaocs/skriptcatchup/elements/conditions/CondIsValid.java
@@ -15,7 +15,7 @@ import ch.njol.skript.doc.Since;
 public class CondIsValid extends PropertyCondition<Entity> {
 
     static {
-        register(CondIsValid.class, "valid [catch[ ]up]", "entities");
+        register(CondIsValid.class, "[catch[ ]up] valid", "entities");
     }
 
     @Override

--- a/src/main/java/jp/nlaocs/skriptcatchup/elements/conditions/CondIsWhitelisted.java
+++ b/src/main/java/jp/nlaocs/skriptcatchup/elements/conditions/CondIsWhitelisted.java
@@ -28,9 +28,9 @@ public class CondIsWhitelisted extends Condition {
 
     static {
         String[] patterns = new String[3];
-        patterns[0] = "[the] server (is|not:(isn't|is not)) (in white[ ]list mode|white[ ]listed) [catch[ ]up]";
-        patterns[1] = "%offlineplayers% (is|are|not:(isn't|is not|aren't|are not)) white[ ]listed [catch[ ]up]";
-        patterns[2] = "[the] server white[ ]list (is|not:(isn't|is not)) enforced [catch[ ]up]";
+        patterns[0] = "[the] server (is|not:(isn't|is not)) [catch[ ]up] (in white[ ]list mode|white[ ]listed)";
+        patterns[1] = "%offlineplayers% (is|are|not:(isn't|is not|aren't|are not)) [catch[ ]up] white[ ]listed";
+        patterns[2] = "[the] server white[ ]list (is|not:(isn't|is not)) [catch[ ]up] enforced";
         Skript.registerCondition(CondIsWhitelisted.class, patterns);
     }
 

--- a/src/main/java/jp/nlaocs/skriptcatchup/elements/conditions/CondPlayedBefore.java
+++ b/src/main/java/jp/nlaocs/skriptcatchup/elements/conditions/CondPlayedBefore.java
@@ -25,8 +25,8 @@ public class CondPlayedBefore extends Condition {
 
     static {
         Skript.registerCondition(CondPlayedBefore.class,
-                "%offlineplayers% [(has|have|did)] [already] play[ed] [on (this|the) server] (before|already) [catch[ ]up]",
-                "%offlineplayers% (has not|hasn't|have not|haven't|did not|didn't) [(already|yet)] play[ed] [on (this|the) server] (before|already|yet) [catch[ ]up]");
+                "%offlineplayers% [(has|have|did)] [catch[ ]up] [already] play[ed] [on (this|the) server] (before|already)",
+                "%offlineplayers% (has not|hasn't|have not|haven't|did not|didn't) [catch[ ]up] [(already|yet)] play[ed] [on (this|the) server] (before|already|yet)");
     }
 
     @SuppressWarnings("null")

--- a/src/main/java/jp/nlaocs/skriptcatchup/elements/conditions/CondWillHatch.java
+++ b/src/main/java/jp/nlaocs/skriptcatchup/elements/conditions/CondWillHatch.java
@@ -23,7 +23,7 @@ public class CondWillHatch extends Condition {
 
     static {
         Skript.registerCondition(CondWillHatch.class,
-                "[the] egg (:will|will not|won't) hatch [catch[ ]up]"
+                "[the] egg (:will|will not|won't) [catch[ ]up] hatch"
         );
     }
 


### PR DESCRIPTION
This reverts commit 54e9d22b97b6af6f549c10421085405808176dbb.

最後に識別子をつけるとパーサーが何らかのobjectだと勘違いするので動詞のあとに記述するように戻す